### PR TITLE
Save coverage and test results files as artifacts of the ci test step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev]
           nox
-          
+      - name: Save code coverage file
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage.xml
+          path: ./coverage.xml
+      - name: Save test result file
+        uses: actions/upload-artifact@v3
+        with:
+          name: test_result.xml
+          path: ./test_result.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Save code coverage file
         uses: actions/upload-artifact@v3
         with:
-          name: coverage.xml
+          name: coverage_${{ matrix.os }}_${{ matrix.python-version }}.xml
           path: ./coverage.xml
       - name: Save test result file
         uses: actions/upload-artifact@v3
         with:
-          name: test_result.xml
+          name: test_result_${{ matrix.os }}_${{ matrix.python-version }}.xml
           path: ./test_result.xml

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+test_result.xml
 
 # Translations
 *.mo

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,6 @@ def type_check(s: nox.Session) -> None:
 
 @nox.session(venv_backend="none")
 def test(s: nox.Session) -> None:
-    s.run("pytest", "--cov")
+    s.run("pytest", "--cov", "--junitxml=test_result.xml")
     s.run("coverage", "report")
     s.run("coverage", "xml")


### PR DESCRIPTION
Enables outputting of code coverage and test results for pytest.
Saves code coverage and test result files as artifacts after the main workflow has finished.