### PR TITLE
Change dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/" 
+    directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Changes dependabot target branch from main to dev to match our new git workflow.