### PR TITLE
Use tags instead of names in noxfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: Run linter
-        run: nox --session lint
+        run: nox -t lint
       - name: Run tests
-        run: nox --session test
+        run: nox -t test
       - name: Save code coverage file
         uses: actions/upload-artifact@v3
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,23 +1,23 @@
 import nox
 
 
-@nox.session(name="lint", venv_backend="none")
+@nox.session(tags=["lint"], venv_backend="none")
 def fmt_check(s: nox.Session) -> None:
     s.run("isort", "--check", ".")
     s.run("black", "--check", ".")
 
 
-@nox.session(name="lint", venv_backend="none")
+@nox.session(tags=["lint"], venv_backend="none")
 def lint(s: nox.Session) -> None:
     s.run("pflake8", "--color", "always", "src", "tests")
 
 
-@nox.session(name="lint", venv_backend="none")
+@nox.session(tags=["lint"], venv_backend="none")
 def type_check(s: nox.Session) -> None:
     s.run("mypy", "src", "noxfile.py")
 
 
-@nox.session(name="test", venv_backend="none")
+@nox.session(tags=["test"], venv_backend="none")
 def test(s: nox.Session) -> None:
     s.run("pytest", "--cov", "--junitxml=test_result.xml")
     s.run("coverage", "report")


### PR DESCRIPTION
Use tags instead of names in noxfile.
Change ci to pass the right parameters to nox.