### PR TITLE
Add automatic format fix step to nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,12 @@ def fmt_check(s: nox.Session) -> None:
     s.run("black", "--check", ".")
 
 
+@nox.session(tags=["fmt"], venv_backend="none")
+def fmt(s: nox.Session) -> None:
+    s.run("isort", ".")
+    s.run("black", ".")
+
+
 @nox.session(tags=["lint"], venv_backend="none")
 def lint(s: nox.Session) -> None:
     s.run(


### PR DESCRIPTION
**Changes:**
* Briefly describe changes
Add an automatic format step (black, isort) to nox, can be called with `nox -s fmt`, as mentioned in the README

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to main.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
