### PR TITLE
pyproject.toml hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,8 @@ module = "dash.*"
 ignore_missing_imports = true
 
 [tool.flake8]
-per-file-ignores = """
-  /tests/*: D100 D101 D102 D10 D104
-  __init__.py: F401
-"""
-select = ["src", "tests"]
-exclude = [".venv", "venv", ".nox", "docs", ".git", ".github"]
-extend-ignore = ["E203"]
+per-file-ignores = "__init__.py: F401"
+exclude = [".venv", "venv", ".nox", "docs", ".git", ".github", "noxfile.py"]
 extend-immutable-calls = ["Argument"]
 max-doc-length = 72
 max-line-length = 99


### PR DESCRIPTION
**Changes:**
Flake8 configuration accidentally disables most errors. This was due to
incorrect usage of the select option. This PR addresses that issue.

This PR also removes some error ignores, as well as some
per-file-ignores.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
