### PR TITLE
Bumb Dash from 2.8.1 to 2.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools", "setuptools-scm"]
 [project]
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-  "dash == 2.8.1",
+  "dash == 2.9.1",
   "pymongo == 4.3.3"
 ]
 name = "pum13-2023"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def browser_driver(request: FixtureRequest):
             driver = webdriver.ChromiumEdge(options=options)
         case _:
             options = webdriver.FirefoxOptions()
-            print(request.config.option.headless)
             if request.config.option.head == "1":
                 options.add_argument("--headless")
             driver = webdriver.Firefox(options=options)


### PR DESCRIPTION
Bump dash to 2.9.1 from 2.8.1


**Changes:**
Removed a print statement in conftest.py that broke the app.
The print worked in 2.8.1 but not in 2.9.1, the print is left over from developing.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
