### PR TITLE
Icon component hotfix

### DIFF
--- a/src/dashboard/components/icon.py
+++ b/src/dashboard/components/icon.py
@@ -8,7 +8,7 @@ from dash import html
 from dash.dependencies import Component
 
 
-def icon_style(fill: int, weight: int, grade: int, size: int) -> dict[str, str]:
+def icon_style(fill: int, weight: int, grade: int) -> dict[str, str]:
     """Return the style dictionary for an icon component.
 
     The style dictionary contains settings for font variations.
@@ -17,15 +17,15 @@ def icon_style(fill: int, weight: int, grade: int, size: int) -> dict[str, str]:
         fill (int): Set to 0 for outlined, 1 for filled.
         weight (int): Font weight for the icon, range 100-700.
         grade (int): Affects font weight, range -25-200.
-        size (int): Font size in pixels, values 20, 24, 40, 48.
     """
     return {
-        "fontVariationSettings": f"'FILL' {fill}, 'wght' {weight}, 'GRAD' {grade}, 'opsz' {size}"
+        "fontVariationSettings": f"'FILL' {fill}, 'wght' {weight}, 'GRAD' {grade}",
+        "fontOpticalSizing": "auto",
     }
 
 
 def icon(
-    icon_name: str, fill: int = 0, weight: int = 400, grade: int = 0, size: int = 48, **kwargs: Any
+    icon_name: str, fill: int = 0, weight: int = 400, grade: int = 0, **kwargs: Any
 ) -> Component:
     """Return an icon component.
 
@@ -36,8 +36,6 @@ def icon(
         weight (int): Font weight for the icon, range 100-700,
             default 400.
         grade (int): Affects font weight, range -25-200, default 0.
-        size (int): Font size in pixels, values 20, 24, 40, 48.
-            Default 48.
         kwargs (Any): Forwarded to html.Span.
 
     Examples:
@@ -48,13 +46,17 @@ def icon(
         Setting icon color::
 
             icon("home", className="text-pink-500")
+
+        Setting icon size::
+
+            icon("home", className="text-[40px]")
     """
     class_name = kwargs.pop("className", "")
     class_name += " material-symbols-outlined"
 
     return html.Span(
         className=class_name,
-        style=icon_style(fill, weight, grade, size),
+        style=icon_style(fill, weight, grade),
         children=icon_name,
         **kwargs,
     )


### PR DESCRIPTION
The size argument to the icon component did not change the font size,
but the optical size, which was not obvious and was not stated in
documentation. This PR removes that parameter, instead setting
optical sizing by automatic css rule.

Also adds example on how to *actually* set size for icons.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
