### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ branches. When adding a new feature branch, a feature branch is created with
 from `dev`. After the release is finalized, the release branch is merged with
 `main` and a release tag is created.
 
+Branches use the `kebab-case` naming convention, where lowercase words are
+separated by dashes.
+
 ## Commit Messages
 Commit messages begin with a short title, summarizing the changes made. The
 title should be capitalized and use the imperative mood. For example, use "fix"


### PR DESCRIPTION
**Changes:**
Add info on branch naming convention. Ideally branches should follow the
naming convention specified, but no such information was previously
available. This commit addresses that.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
