### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 <!-- fill in with [x] -->
 - [ ] Set target branch to the correct branch, usually `dev`.
 - [ ] Rebased source branch from the target branch.
-- [ ] Ensured code is formatted, linted.
+- [ ] Ensured code is formatted and linted.
 - [ ] Cleaned up git history.
-- [ ] Ensured commit messages describe *what* was changed, and *why*.
-- [ ] Ran tests locally after rebasing, checked output.
+- [ ] Ensured commit messages describe *what* was changed and *why*.
+- [ ] Ran tests locally after rebasing and checked output.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,11 @@
-**Fix ...**
-
 **Changes:**
 * Briefly describe changes
 
 **I have:**
 <!-- fill in with [x] -->
 - [ ] Set target branch to the correct branch, usually `dev`.
+- [ ] Rebased source branch from the target branch.
 - [ ] Ensured code is formatted, linted.
 - [ ] Cleaned up git history.
 - [ ] Ensured commit messages describe *what* was changed, and *why*.
-- [ ] Ran tests locally, checked output.
+- [ ] Ran tests locally after rebasing, checked output.


### PR DESCRIPTION
**Changes:**
To promote better CI practices, branches should *at least* be rebased
before a pull request.

Also removed an unneccessary header in the template.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Ensured code is formatted, linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed, and *why*.
- [x] Ran tests locally, checked output.
