### PR TITLE
Fix custom button background color

### DIFF
--- a/src/dashboard/components/button.py
+++ b/src/dashboard/components/button.py
@@ -38,11 +38,13 @@ def button(
     """
     class_name = kwargs.pop("className", "")
     _icon_kwargs: IconKWArgs = icon_kwargs if icon_kwargs else {}
+    if "bg-" not in class_name:
+        class_name += " bg-white"
 
     return html.Button(
         **kwargs,
         className=(
-            f"{class_name} flex bg-white items-center text-[{size}px] px-2 py-1 rounded-lg"
+            f"{class_name} flex items-center text-[{size}px] px-2 py-1 rounded-lg"
             " drop-shadow-sm hover:drop-shadow-md transition"
         ),
         children=[


### PR DESCRIPTION
**Changes:**
Button now only sets a default white background color classname if there was none passed to the button kwargs. Before, arbitrary background color values were not prioritized above i.e bg-white in tailwind's stylesheets and thus did not work properly. Resolves #118 

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Rebased source branch from the target branch.
- [x] Ensured code is formatted and linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed and *why*.
- [x] Ran tests locally after rebasing and checked output.
