### PR TITLE
Add datetime created and modified to dashboard model

### DIFF
--- a/src/dashboard/models/user.py
+++ b/src/dashboard/models/user.py
@@ -1,11 +1,16 @@
 """Models related to user database."""
+from datetime import datetime
+from typing import Any
+
 from mongoengine import (
+    DateTimeField,
     Document,
     EmbeddedDocument,
     EmbeddedDocumentListField,
     ListField,
     ReferenceField,
     StringField,
+    signals,
 )
 
 
@@ -41,8 +46,19 @@ class Dashboard(EmbeddedDocument):
 
     name: str = StringField()
     description: str = StringField()
+    modified: datetime = DateTimeField()
+    created: datetime = DateTimeField()
     authorized_users: list["User"] = ListField(ReferenceField("User"))
     diagrams: list[Diagram] = EmbeddedDocumentListField(Diagram)
+
+    @staticmethod
+    def post_init(sender: type, document: "Dashboard", **kwargs: Any) -> None:
+        """Initialize time information."""
+        document.created = datetime.now()
+        document.modified = document.created
+
+
+signals.post_init.connect(Dashboard.post_init, sender=Dashboard)
 
 
 class User(Document):

--- a/src/dashboard/models/user.py
+++ b/src/dashboard/models/user.py
@@ -46,16 +46,21 @@ class Dashboard(EmbeddedDocument):
 
     name: str = StringField()
     description: str = StringField()
-    modified: datetime = DateTimeField()
-    created: datetime = DateTimeField()
+    modified: datetime | None = DateTimeField()
+    created: datetime | None = DateTimeField()
     authorized_users: list["User"] = ListField(ReferenceField("User"))
     diagrams: list[Diagram] = EmbeddedDocumentListField(Diagram)
+
+    def update_modified(self) -> None:
+        """Sets self.modified to datetime.now()."""
+        self.modified = datetime.now()
 
     @staticmethod
     def post_init(sender: type, document: "Dashboard", **kwargs: Any) -> None:
         """Initialize time information."""
-        document.created = datetime.now()
-        document.modified = document.created
+        if not document.created:
+            document.update_modified()
+            document.created = document.modified
 
 
 signals.post_init.connect(Dashboard.post_init, sender=Dashboard)

--- a/tests/test_user_db.py
+++ b/tests/test_user_db.py
@@ -22,7 +22,6 @@ def example_user():
     """Example user."""
     username = "fixture-user"
     usr = user.login_user(username)
-    usr.dashboards.clear()
     usr.dashboards.append(user.Dashboard())
     usr.save()
     return usr


### PR DESCRIPTION
**Changes:**
* Add created and modified fields to dashboard model
* Add post_init to set created and modified to datetime.now()

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Rebased source branch from the target branch.
- [x] Ensured code is formatted and linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed and *why*.
- [x] Ran tests locally after rebasing and checked output.
