### PR TITLE
Change so all the test uses the DriverType type.

### DIFF
--- a/tests/helper_test_functions.py
+++ b/tests/helper_test_functions.py
@@ -1,11 +1,11 @@
 """Helper functions for test."""
 
-from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.wait import WebDriverWait
+from tests.settings import DriverType
 
 from . import settings
 
@@ -24,7 +24,7 @@ ID_LOGIN_BUTTON_ELEMENT = "login_button"
 ID_LOGOUT_ELEMENT = "logout_element"
 
 
-def is_in_login_screen(driver: webdriver) -> None:
+def is_in_login_screen(driver: DriverType) -> None:
     """Check if the driver is currently at the login screen.
 
     This functions checks if the driver is in the login screen
@@ -38,7 +38,7 @@ def is_in_login_screen(driver: webdriver) -> None:
     assert get_element_by_id(driver, ID_PASSWORD_ELEMENT) is not None, msg
 
 
-def is_in_home_page(driver: webdriver) -> None:
+def is_in_home_page(driver: DriverType) -> None:
     """Check if the driver is currently at the home page.
 
     This functions checks if the driver is in the home page
@@ -53,7 +53,7 @@ def is_in_home_page(driver: webdriver) -> None:
     # assert get_element_by_id(driver, ID_LOGOUT_ELEMENT) is not None
 
 
-def try_login(driver: webdriver, username: str, password: str) -> None:
+def try_login(driver: DriverType, username: str, password: str) -> None:
     """Try to login to the homepage.
 
     This functions tries to login to the home page.
@@ -80,7 +80,7 @@ def try_login(driver: webdriver, username: str, password: str) -> None:
     login_button.click()
 
 
-def get_element_by_id(driver: webdriver, element_id: str) -> WebElement:
+def get_element_by_id(driver: DriverType, element_id: str) -> WebElement:
     """Get element by their id.
 
     This function would try to get the element by id. If the
@@ -108,11 +108,11 @@ def get_element_by_id(driver: webdriver, element_id: str) -> WebElement:
     return elements[0]
 
 
-def get_element_by_css_selector(driver: webdriver, css_selector: str) -> WebElement:
+def get_element_by_css_selector(driver: DriverType, css_selector: str) -> WebElement:
     """Get element using a css selector.
 
     Args:
-        driver (webdriver): The web driver to use.
+        driver (webdriver): The webdriver to use.
         css_selector (str): The css slector to use. This
         can be copied from your browser's web tools when
         inspecting the relevant element.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,8 @@
 """Test login capabilities of the app."""
 
 import pytest
-from selenium import webdriver
 from selenium.webdriver.remote.webelement import WebElement
+from tests.settings import DriverType
 
 from . import helper_test_functions as helper
 from . import settings
@@ -45,7 +45,7 @@ class TestCreateDashboard:
 
     @pytest.mark.test_creating_home_page
     @pytest.mark.usefixtures("browser_driver")
-    def test_creating_home_page(self, browser_driver: webdriver):
+    def test_creating_home_page(self, browser_driver: DriverType):
         """Try to create the dashboard from the home screen.
 
         This function would login the homepage and then press the
@@ -97,7 +97,7 @@ class TestCreateDashboard:
         self.check_dashboard_created(browser_driver, DASHBOARD_TITLE_1)
 
     @pytest.mark.test_creating_dashboard_page
-    def test_creating_dashboard_page(self, browser_driver: webdriver):
+    def test_creating_dashboard_page(self, browser_driver: DriverType):
         """Try to create a dashboard from the dashboard page.
 
         This function would login the homepage and then press the
@@ -147,7 +147,7 @@ class TestCreateDashboard:
         # Test if the dashboard was created
         self.check_dashboard_created(browser_driver, DASHBOARD_TITLE_2)
 
-    def check_dashboard_created(self, browser_driver: webdriver, dashboard_title: str) -> None:
+    def check_dashboard_created(self, browser_driver: DriverType, dashboard_title: str) -> None:
         """Check if the dashboard was created with the given title.
 
         This function checks if the created dashboard has the right
@@ -155,8 +155,8 @@ class TestCreateDashboard:
         inside the dashboard that has been created.
 
         Args:
-            browser_driver (webdriver): It is the webdriver in which we
-            are going to check if the popup exist.
+            browser_driver (webdriver): It is the webdriver in which
+            we are going to check if the popup exist.
 
             dashboard_title (str): The title of the dashboard that
             was created.

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,10 +1,10 @@
 """Test login capabilities of the app."""
 import pytest
-from selenium import webdriver
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.wait import WebDriverWait
 from tests import helper_test_functions as helper
 from tests import settings
+from tests.settings import DriverType
 
 # Login credentials for the unvalid test user
 WRONG_USERNAME = "not_valid_user"
@@ -20,7 +20,7 @@ class TestLogin:
     """A class to group functions to test the login capabilities."""
 
     @pytest.mark.usefixtures("start_server")
-    def test_unsuccessful_login(self, browser_driver: webdriver):
+    def test_unsuccessful_login(self, browser_driver: DriverType):
         """Try to login with invalid username and password."""
         browser_driver.get(settings.START_PAGE_URL)
         # Try logging in with wrong password and username
@@ -36,7 +36,7 @@ class TestLogin:
         self.check_login_error_pop_up(browser_driver)
 
     @pytest.mark.usefixtures("start_server")
-    def test_successfull_login(self, browser_driver: webdriver):
+    def test_successfull_login(self, browser_driver: DriverType):
         """Try to login to the system."""
         browser_driver.get(settings.START_PAGE_URL)
         helper.try_login(browser_driver, settings.USERS_USERNAME, settings.USERS_PASSWORD)
@@ -49,7 +49,7 @@ class TestLogin:
         helper.is_in_home_page(browser_driver)
 
     @pytest.mark.usefixtures("start_server")
-    def test_logout(self, browser_driver: webdriver):
+    def test_logout(self, browser_driver: DriverType):
         """A test that would try to log out from the system."""
         browser_driver.get(settings.START_PAGE_URL)
         helper.try_login(browser_driver, settings.USERS_USERNAME, settings.USERS_PASSWORD)
@@ -67,7 +67,7 @@ class TestLogin:
 
         helper.is_in_login_screen(browser_driver)
 
-    def check_login_error_pop_up(self, driver: webdriver) -> None:
+    def check_login_error_pop_up(self, driver: DriverType) -> None:
         """Check if the login pop up error is correctly implemented.
 
         This function test checks if the login pop up error by first
@@ -79,7 +79,7 @@ class TestLogin:
         visible when calling this functions.
 
         Args:
-            driver (webdriver): It is the webdriver in which
+            driver (DriverType): It is the DriverType in which
             we are going to check if the popup exist.
         """
         # Check if the login error pop up exist and then
@@ -90,14 +90,14 @@ class TestLogin:
         driver.refresh()
         assert not self.error_pop_up_exist(driver), pop_up_refresh_msg
 
-    def error_pop_up_exist(self, driver: webdriver) -> bool:
+    def error_pop_up_exist(self, driver: DriverType) -> bool:
         """Check if pop up error exist.
 
         It will return false if it does not exist and true if the
         popup error exist.
 
         Args:
-            driver (webdriver): It is the webdriver in which
+            driver (DriverType): It is the DriverType in which
             we are going to
 
             check if the popup exist.

--- a/tests/test_navbar_component.py
+++ b/tests/test_navbar_component.py
@@ -1,11 +1,11 @@
 """Test for navbar functionality."""
 import pytest
-from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.wait import WebDriverWait
 from tests import helper_test_functions as helper
 from tests import settings
+from tests.settings import DriverType
 
 NAVBAR_COUNT = 4
 NAVBAR_CONTAINER_ID = "main-navbar"
@@ -19,7 +19,7 @@ class TestNavbarComponent:
     """Class that tests the Navbar component."""
 
     @pytest.mark.usefixtures("start_server")
-    def test_find_navbar(self, browser_driver: webdriver) -> None:
+    def test_find_navbar(self, browser_driver: DriverType) -> None:
         """Test that a navbar element exists on the page."""
         browser_driver.get(settings.URL)
 
@@ -32,7 +32,7 @@ class TestNavbarComponent:
         assert navbar, "Navbar could not be found"
 
     @pytest.mark.usefixtures("start_server")
-    def test_find_buttons(self, browser_driver: webdriver) -> None:
+    def test_find_buttons(self, browser_driver: DriverType) -> None:
         """Test that the navbar items exist on the page."""
         browser_driver.get(settings.URL)
         WebDriverWait(browser_driver, settings.NORMAL_TIMEOUT).until(
@@ -47,7 +47,7 @@ class TestNavbarComponent:
         assert len(navbar_items) == NAVBAR_COUNT, "Navbar items do not exist"
 
     @pytest.mark.usefixtures("start_server")
-    def test_redirect(self, browser_driver: webdriver) -> None:
+    def test_redirect(self, browser_driver: DriverType) -> None:
         """Test so Shared Dashboards item redirects to correct page."""
         browser_driver.get(settings.URL)
 
@@ -73,7 +73,7 @@ class TestNavbarComponent:
         )
 
     def redirect_navbar(
-        self, browser_driver: webdriver, element_id: str, browser_url: str, page: str
+        self, browser_driver: DriverType, element_id: str, browser_url: str, page: str
     ):
         """Helper to test_redirect navbar that presses the element."""
         # Press the dashboard button and


### PR DESCRIPTION
#126 

All the test type hinting should be now using DriverType instead of webdriver. This is done because webdriver is not a type.

**I have:**
<!-- fill in with [x] -->
- [X] Set target branch to the correct branch, usually `dev`.
- [X] Rebased source branch from the target branch.
- [X] Ensured code is formatted and linted.
- [X] Cleaned up git history.
- [X] Ensured commit messages describe *what* was changed and *why*.
- [X] Ran tests locally after rebasing and checked output.
