### PR TITLE
Home page create dashboard modal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ strict = true
 
 
 [[tool.mypy.overrides]]
-module = ["dash.*", "plotly.*", "dash_bootstrap_components.*", "jsonpickle.*", "flask_login.*"]
+module = ["dash.*", "plotly.*", "dash_bootstrap_components.*", "jsonpickle.*", "dash_daq.*", "flask_login.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "jsonpickle == 3.0.1",
   "flask-login == 0.6.2",
   "kaleido == 0.2.1",
+  "dash-daq == 0.5.0",
 ]
 name = "pum13-2023"
 description = "Data visualization dashboard written with Dash"

--- a/src/dashboard/assets/dashboard.css
+++ b/src/dashboard/assets/dashboard.css
@@ -771,29 +771,14 @@ video {
   height: 350px;
 }
 
-<<<<<<< HEAD
-.h-\[62\%\] {
-  height: 62%;
-}
-
-.h-\[70\%\] {
-  height: 70%;
-}
-
-.h-\[80\%\] {
-  height: 80%;
-}
-
-.h-\[9\%\] {
-  height: 9%;
-}
-
-=======
 .h-\[70\] {
   height: 70%;
 }
 
->>>>>>> 86b4748 (Update css)
+.h-\[5rem\] {
+  height: 5rem;
+}
+
 .h-fit {
   height: -moz-fit-content;
   height: fit-content;
@@ -953,6 +938,10 @@ video {
 
 .justify-between {
   justify-content: space-between;
+}
+
+.justify-end {
+  justify-content: end;
 }
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {

--- a/src/dashboard/assets/dashboard.css
+++ b/src/dashboard/assets/dashboard.css
@@ -771,6 +771,7 @@ video {
   height: 350px;
 }
 
+<<<<<<< HEAD
 .h-\[62\%\] {
   height: 62%;
 }
@@ -787,6 +788,12 @@ video {
   height: 9%;
 }
 
+=======
+.h-\[70\] {
+  height: 70%;
+}
+
+>>>>>>> 86b4748 (Update css)
 .h-fit {
   height: -moz-fit-content;
   height: fit-content;
@@ -1407,6 +1414,10 @@ video {
 .drop-shadow-sm {
   --tw-drop-shadow: drop-shadow(0 1px 1px rgb(0 0 0 / 0.05));
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.shadow-inner {
+  box-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
 }
 
 .grayscale {

--- a/src/dashboard/components/__init__.py
+++ b/src/dashboard/components/__init__.py
@@ -1,7 +1,19 @@
+from dashboard.components.add_dashboard_modal import add_dashboard_modal
 from dashboard.components.auth import login_required
 from dashboard.components.button import button
 from dashboard.components.dashboards_list_component import dashboards_list_component
 from dashboard.components.icon import icon
-from dashboard.components.navbar_component import navbar_component as navbar
+from dashboard.components.multiline_input import multiline_input
+from dashboard.components.navbar_component import navbar_component
+from dashboard.components.text_input import text_input
 
-__all__ = ["button", "dashboards_list_component", "icon", "navbar", "login_required"]
+__all__ = [
+    "button",
+    "dashboards_list_component",
+    "icon",
+    "navbar_component",
+    "login_required",
+    "add_dashboard_modal",
+    "text_input",
+    "multiline_input",
+]

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,7 +1,10 @@
 """Modal for add dashboard buttons."""
 from dash import html
 
-from dashboard.components import button, modal, multiline_input, text_input
+from dashboard.components import modal
+from dashboard.components.button import button
+from dashboard.components.multiline_input import multiline_input
+from dashboard.components.text_input import text_input
 
 
 def generate_inputs() -> html.Div:

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -28,24 +28,20 @@ def generate_buttons() -> html.Div:
                   dashboard
     """
     return html.Div(
+        className="flex bg-menu-back px-[5rem] justify-end h-[5rem] py-3",
         children=[
-            html.Div(
-                className="flex bg-menu-back px-[5rem] justify-end h-[5rem] py-3",
-                children=[
-                    button(
-                        id="cancel-btn",
-                        icon_name="",
-                        text="Cancel",
-                        className="bg-none text-white",
-                    ),
-                    button(
-                        id="add-dashboard",
-                        icon_name="",
-                        text="Create dashboard",
-                        className="bg-dark-purple text-white p-5",
-                    ),
-                ],
-            )
+            button(
+                id="cancel-btn",
+                icon_name="",
+                text="Cancel",
+                className="bg-none text-white",
+            ),
+            button(
+                id="add-dashboard",
+                icon_name="",
+                text="Create dashboard",
+                className="bg-dark-purple text-white p-5",
+            ),
         ],
     )
 
@@ -79,9 +75,7 @@ def add_dashboard_modal() -> html.Div:
                         id="add-dashboard-container",
                         className="shadow-md w-[40rem] rounded-md overflow-hidden",
                         children=[
-                            html.Div(
-                                generate_inputs(),
-                            ),
+                            generate_inputs(),
                             generate_buttons(),
                         ],
                     )

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,7 +1,7 @@
 """Modal for add dashboard buttons."""
 from dash import html
 
-from dashboard.components import modal, multiline_input, text_input, button
+from dashboard.components import button, modal, multiline_input, text_input
 
 
 def generate_inputs() -> html.Div:

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,10 +1,7 @@
 """Modal for add dashboard buttons."""
 from dash import html
 
-from dashboard.components import modal
-from dashboard.components.button import button
-from dashboard.components.multiline_input import multiline_input
-from dashboard.components.text_input import text_input
+from dashboard.components import modal, multiline_input, text_input, button
 
 
 def generate_inputs() -> html.Div:

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,0 +1,116 @@
+"""Modal for add dashboard buttons."""
+from dash import dcc, html
+
+from dashboard.components.button import button
+
+
+def input(id: str, title: str, description: str) -> html.Div:
+    """Pre-styled input field.
+
+    Args:
+        id (str): Input id
+        title (str): input title
+        description (str): placeholder of the input
+
+    Returns:
+        html.Div: A pre-styled input with a title and placeholder
+    """
+    return html.Div(
+        className="flex flex-col",
+        children=[
+            html.P(title, className=""),
+            dcc.Input(
+                id=id,
+                className="p-3 rounded-md shadow-inner bg-background",
+                placeholder=description,
+            ),
+        ],
+    )
+
+
+def multiline_input(id: str, title: str, description: str) -> html.Div:
+    """Pre-styled multiline input.
+
+    Args:
+        id (str): id of the multiline input
+        title (str): title of the multiline input
+        description (str): placeholder of the multiline input
+
+    Returns:
+        html.Div: A pre-styled multiline input with a title and placeholder
+    """
+    return html.Div(
+        className="flex flex-col",
+        children=[
+            html.P(title, className=""),
+            dcc.Textarea(
+                id=id,
+                draggable=False,
+                className="p-3 rounded-md shadow-inner h-[17rem] bg-background",
+                placeholder=description,
+            ),
+        ],
+    )
+
+
+def inputs() -> html.Div:
+    """Input container.
+
+    Returns:
+        html.Div: Div containing the text inputs
+    """
+    return html.Div(
+        className="flex flex-col px-[5rem] py-5 space-y-4",
+        children=[
+            html.P("Create dashboard", className="text-3xl"),
+            input("dashboard-title", "Dashboard title", "Enter dashboard title..."),
+            multiline_input("dashboard-desc", "Description", "Enter dashboard description..."),
+        ],
+    )
+
+
+def buttons() -> html.Div:
+    """Container for the modal buttons.
+
+    Returns:
+        html.Div: A container with buttons for cancel and create dashboard
+    """
+    return html.Div(
+        children=[
+            html.Div(
+                className="flex bg-menu-back px-[5rem] justify-end h-[5rem] py-3",
+                children=[
+                    button(
+                        id="cancel-btn",
+                        icon_name="",
+                        text="Cancel",
+                        className="bg-none text-white",
+                    ),
+                    button(
+                        id="add-dashboard",
+                        icon_name="",
+                        text="Create dashboard",
+                        className="bg-dark-purple text-white p-5",
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def add_dashboard_modal() -> html.Div:
+    """Whole container for the modal.
+
+    Returns:
+        html.Div: Contains the inputs and buttons
+    """
+    return html.Div(
+        id="add-dashboard-container",
+        className="shadow-md w-[40rem] rounded-md overflow-hidden",
+        children=[
+            html.Div(
+                inputs(),
+            ),
+            html.Div(buttons()),
+        ],
+    )

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,6 +1,7 @@
 """Modal for add dashboard buttons."""
 from dash import dcc, html
 
+from dashboard.components import modal
 from dashboard.components.button import button
 
 
@@ -37,7 +38,7 @@ def multiline_input(id: str, title: str, description: str) -> html.Div:
         description (str): placeholder of the multiline input
 
     Returns:
-        html.Div: A pre-styled multiline input with a title and placeholder
+        html.Div: pre-styled multiline input with title and placeholder
     """
     return html.Div(
         className="flex flex-col",
@@ -73,7 +74,8 @@ def buttons() -> html.Div:
     """Container for the modal buttons.
 
     Returns:
-        html.Div: A container with buttons for cancel and create dashboard
+        html.Div: Container with buttons for cancel and create
+                  dashboard
     """
     return html.Div(
         children=[
@@ -101,16 +103,39 @@ def buttons() -> html.Div:
 def add_dashboard_modal() -> html.Div:
     """Whole container for the modal.
 
+    This is the function used for the create dashboard modal.
+    If you want to use this predefined modal component create
+    a callback that modifies the add-dashboard-dialog open
+    property.
+
+    Example:
+        @callback(
+            Output({"type": "modal-dialog",
+                    "id": "add-dashboard-dialog"},
+                    "open", allow_duplicate=True),
+            Input("some_input", "property"),
+            prevent_initial_call=True,
+        )
+
     Returns:
         html.Div: Contains the inputs and buttons
     """
-    return html.Div(
-        id="add-dashboard-container",
-        className="shadow-md w-[40rem] rounded-md overflow-hidden",
+    return modal.modal_container(
         children=[
-            html.Div(
-                inputs(),
-            ),
-            html.Div(buttons()),
-        ],
+            modal.modal_dialog(
+                id="add-dashboard-dialog",
+                children=[
+                    html.Div(
+                        id="add-dashboard-container",
+                        className="shadow-md w-[40rem] rounded-md overflow-hidden",
+                        children=[
+                            html.Div(
+                                inputs(),
+                            ),
+                            html.Div(buttons()),
+                        ],
+                    )
+                ],
+            )
+        ]
     )

--- a/src/dashboard/components/add_dashboard_modal.py
+++ b/src/dashboard/components/add_dashboard_modal.py
@@ -1,60 +1,13 @@
 """Modal for add dashboard buttons."""
-from dash import dcc, html
+from dash import html
 
 from dashboard.components import modal
 from dashboard.components.button import button
+from dashboard.components.multiline_input import multiline_input
+from dashboard.components.text_input import text_input
 
 
-def input(id: str, title: str, description: str) -> html.Div:
-    """Pre-styled input field.
-
-    Args:
-        id (str): Input id
-        title (str): input title
-        description (str): placeholder of the input
-
-    Returns:
-        html.Div: A pre-styled input with a title and placeholder
-    """
-    return html.Div(
-        className="flex flex-col",
-        children=[
-            html.P(title, className=""),
-            dcc.Input(
-                id=id,
-                className="p-3 rounded-md shadow-inner bg-background",
-                placeholder=description,
-            ),
-        ],
-    )
-
-
-def multiline_input(id: str, title: str, description: str) -> html.Div:
-    """Pre-styled multiline input.
-
-    Args:
-        id (str): id of the multiline input
-        title (str): title of the multiline input
-        description (str): placeholder of the multiline input
-
-    Returns:
-        html.Div: pre-styled multiline input with title and placeholder
-    """
-    return html.Div(
-        className="flex flex-col",
-        children=[
-            html.P(title, className=""),
-            dcc.Textarea(
-                id=id,
-                draggable=False,
-                className="p-3 rounded-md shadow-inner h-[17rem] bg-background",
-                placeholder=description,
-            ),
-        ],
-    )
-
-
-def inputs() -> html.Div:
+def generate_inputs() -> html.Div:
     """Input container.
 
     Returns:
@@ -64,13 +17,13 @@ def inputs() -> html.Div:
         className="flex flex-col px-[5rem] py-5 space-y-4",
         children=[
             html.P("Create dashboard", className="text-3xl"),
-            input("dashboard-title", "Dashboard title", "Enter dashboard title..."),
+            text_input("dashboard-title", "Dashboard title", "Enter dashboard title..."),
             multiline_input("dashboard-desc", "Description", "Enter dashboard description..."),
         ],
     )
 
 
-def buttons() -> html.Div:
+def generate_buttons() -> html.Div:
     """Container for the modal buttons.
 
     Returns:
@@ -130,9 +83,9 @@ def add_dashboard_modal() -> html.Div:
                         className="shadow-md w-[40rem] rounded-md overflow-hidden",
                         children=[
                             html.Div(
-                                inputs(),
+                                generate_inputs(),
                             ),
-                            html.Div(buttons()),
+                            generate_buttons(),
                         ],
                     )
                 ],

--- a/src/dashboard/components/multiline_input.py
+++ b/src/dashboard/components/multiline_input.py
@@ -1,0 +1,29 @@
+"""A pre-styled multiline input component."""
+
+
+from dash import dcc, html
+
+
+def multiline_input(id: str, title: str, description: str) -> html.Div:
+    """Pre-styled multiline input.
+
+    Args:
+        id (str): id of the multiline input
+        title (str): title of the multiline input
+        description (str): placeholder of the multiline input
+
+    Returns:
+        html.Div: pre-styled multiline input with title and placeholder
+    """
+    return html.Div(
+        className="flex flex-col",
+        children=[
+            html.P(title, className=""),
+            dcc.Textarea(
+                id=id,
+                draggable=False,
+                className="p-3 rounded-md shadow-inner h-[17rem] bg-background",
+                placeholder=description,
+            ),
+        ],
+    )

--- a/src/dashboard/components/multiline_input.py
+++ b/src/dashboard/components/multiline_input.py
@@ -18,7 +18,7 @@ def multiline_input(id: str, title: str, description: str) -> html.Div:
     return html.Div(
         className="flex flex-col",
         children=[
-            html.P(title, className=""),
+            html.Label(title),
             dcc.Textarea(
                 id=id,
                 draggable=False,

--- a/src/dashboard/components/text_input.py
+++ b/src/dashboard/components/text_input.py
@@ -1,0 +1,27 @@
+"""A pre-styled text input component."""
+
+from dash import dcc, html
+
+
+def text_input(id: str, title: str, description: str) -> html.Div:
+    """Pre-styled text input field.
+
+    Args:
+        id (str): input id
+        title (str): input title
+        description (str): placeholder of the input
+
+    Returns:
+        html.Div: A pre-styled input with a title and placeholder
+    """
+    return html.Div(
+        className="flex flex-col",
+        children=[
+            html.P(title, className=""),
+            dcc.Input(
+                id=id,
+                className="p-3 rounded-md shadow-inner bg-background",
+                placeholder=description,
+            ),
+        ],
+    )

--- a/src/dashboard/components/text_input.py
+++ b/src/dashboard/components/text_input.py
@@ -17,7 +17,7 @@ def text_input(id: str, title: str, description: str) -> html.Div:
     return html.Div(
         className="flex flex-col",
         children=[
-            html.P(title, className=""),
+            html.Label(title),
             dcc.Input(
                 id=id,
                 className="p-3 rounded-md shadow-inner bg-background",

--- a/src/dashboard/models/user.py
+++ b/src/dashboard/models/user.py
@@ -136,6 +136,17 @@ class User(Document):
         """
         return str(self.id)
 
+    def add_dashboard(self, name: str, desc: str) -> None:
+        """Adds dashboard to mongoDB.
+
+        Args:
+            name (str): Dashboard name
+            desc (str): Dashboard description
+        """
+        added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
+        self.dashboards.append(added_dashboard)
+        self.save()
+
 
 def register_user(username: str) -> User:
     """Register a new user.
@@ -181,16 +192,3 @@ def login_user(username: str) -> User:
     flask_login.login_user(user)
 
     return user
-
-
-def add_dashboard(name: str, desc: str) -> None:
-    """Adds dashboard to mongoDB.
-
-    Args:
-        name (str): Dashboard name
-        desc (str): Dashboard description
-    """
-    test_user = login_user("dashboards-page-test-user")
-    added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
-    test_user.dashboards.append(added_dashboard)
-    test_user.save()

--- a/src/dashboard/models/user.py
+++ b/src/dashboard/models/user.py
@@ -181,3 +181,16 @@ def login_user(username: str) -> User:
     flask_login.login_user(user)
 
     return user
+
+
+def add_dashboard(name: str, desc: str) -> None:
+    """Adds dashboard to mongoDB.
+
+    Args:
+        name (str): Dashboard name
+        desc (str): Dashboard description
+    """
+    test_user = login_user("dashboards-page-test-user")
+    added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
+    test_user.dashboards.append(added_dashboard)
+    test_user.save()

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -5,7 +5,7 @@ of now it is just a stub.
 """
 from datetime import datetime
 
-from dash import ALL, Input, Output, State, callback, ctx
+from dash import Input, Output, State, callback, ctx
 
 from dashboard.models.user import Dashboard, login_user
 
@@ -19,6 +19,15 @@ input_css = "p-3 rounded-md shadow-inner bg-background "
     prevent_initial_call=True,
 )
 def toggle_create_dashboard(create_btn: int, cancel_btn: int) -> bool:
+    """Toggles the create dashboard modal.
+
+    Args:
+        create_btn (int): create dashboard button clicks
+        cancel_btn (int): cancel button clicks
+
+    Returns:
+        bool: value to toggle modal
+    """
     if "cancel-btn" == ctx.triggered_id:
         return False
     return True
@@ -33,19 +42,17 @@ def toggle_create_dashboard(create_btn: int, cancel_btn: int) -> bool:
     State("dashboard-desc", "value"),
     prevent_initial_call=True,
 )
-def add_dashboard_db(n_clicks: int, title: str, desc: str) -> bool | bool | bool:
-    """TODO
-        * Add empty title and desc error
-        * Remove invalid characters
-        * Add max length
+def add_dashboard_db(n_clicks: int, title: str, desc: str) -> tuple[bool, bool, bool]:
+    """Callback to add a new dashboard.
 
     Args:
-        n_clicks (int): _description_
-        title (str): _description_
-        desc (str): _description_
+        n_clicks (int): n_clicks for the button
+        title (str): Dashboard title
+        desc (str): Dashboard description
 
     Returns:
-        _type_: _description_
+        tuple[bool, bool, bool]: toggle modal bool, empty title bool,
+                                 empty desc bool
     """
     # Dash callback gives warnings if you pass bools to value but works
     empty_title = False
@@ -74,10 +81,20 @@ def add_dashboard_db(n_clicks: int, title: str, desc: str) -> bool | bool | bool
     Input("desc", "on"),
     prevent_initial_call=True,
 )
-def display_error(title_err: bool, desc_err: bool) -> str | str | str | str:
+def display_error(title_err: bool, desc_err: bool) -> tuple[str, str, str, str]:
+    """Callback to display error if title or description is empty.
+
+    Args:
+        title_err (bool): Title empty or not
+        desc_err (bool): Description empty or not
+
+    Returns:
+        tuple[str, str, str , str]: title, desc, title placeholder,
+                                    desc placeholder
+    """
     title = [input_css, ""]
     desc = [input_css, ""]
-    print(desc_err)
+
     if title_err:
         title[0] += "bg-red-100"
         title[1] = "Title cannot be empty"
@@ -92,6 +109,12 @@ def display_error(title_err: bool, desc_err: bool) -> str | str | str | str:
 
 
 def add_dashboard(name: str, desc: str) -> None:
+    """Adds dashboard to mongoDB.
+
+    Args:
+        name (str): Dashboard name
+        desc (str): Dashboard description
+    """
     test_user = login_user("dashboards-page-test-user")
     added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
     test_user.dashboards.append(added_dashboard)

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -6,8 +6,7 @@ and submitting a new dashboard.
 """
 
 from dash import Input, Output, State, callback, ctx
-
-from dashboard.models.user import add_dashboard
+from flask_login import current_user
 
 input_css = "p-3 rounded-md shadow-inner bg-background "
 
@@ -85,7 +84,7 @@ def add_dashboard_db(n_clicks: int, title: str, desc: str) -> tuple[bool, bool, 
 
     if desc and title:
         open = False
-        add_dashboard(title, desc)
+        current_user.add_dashboard(title, desc)
 
     return open, empty_title, empty_desc
 

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -3,8 +3,96 @@
 This module is intented to contain callbacks used in the index page. As
 of now it is just a stub.
 """
+from datetime import datetime
+
+from dash import ALL, Input, Output, State, callback, ctx
+
+from dashboard.models.user import Dashboard, login_user
+
+input_css = "p-3 rounded-md shadow-inner bg-background "
 
 
-def do_stuff() -> bool:
-    """Stub function."""
+@callback(
+    Output({"type": "modal-dialog", "id": "add-dashboard-dialog"}, "open", allow_duplicate=True),
+    Input("create-dashboard-btn", "n_clicks"),
+    Input("cancel-btn", "n_clicks"),
+    prevent_initial_call=True,
+)
+def toggle_create_dashboard(create_btn: int, cancel_btn: int) -> bool:
+    if "cancel-btn" == ctx.triggered_id:
+        return False
     return True
+
+
+@callback(
+    Output({"type": "modal-dialog", "id": "add-dashboard-dialog"}, "open", allow_duplicate=True),
+    Output("title", "on"),
+    Output("desc", "on"),
+    Input("add-dashboard", "n_clicks"),
+    State("dashboard-title", "value"),
+    State("dashboard-desc", "value"),
+    prevent_initial_call=True,
+)
+def add_dashboard_db(n_clicks: int, title: str, desc: str) -> bool | bool | bool:
+    """TODO
+        * Add empty title and desc error
+        * Remove invalid characters
+        * Add max length
+
+    Args:
+        n_clicks (int): _description_
+        title (str): _description_
+        desc (str): _description_
+
+    Returns:
+        _type_: _description_
+    """
+    # Dash callback gives warnings if you pass bools to value but works
+    empty_title = False
+    empty_desc = False
+    valid = False
+
+    if title is None:
+        empty_title = True
+
+    if desc is None:
+        empty_desc = True
+
+    if desc and title:
+        valid = True
+        add_dashboard(title, desc)
+
+    return not valid, empty_title, empty_desc
+
+
+@callback(
+    Output("dashboard-title", "className"),
+    Output("dashboard-desc", "className"),
+    Output("dashboard-title", "placeholder"),
+    Output("dashboard-desc", "placeholder"),
+    Input("title", "on"),
+    Input("desc", "on"),
+    prevent_initial_call=True,
+)
+def display_error(title_err: bool, desc_err: bool) -> str | str | str | str:
+    title = [input_css, ""]
+    desc = [input_css, ""]
+    print(desc_err)
+    if title_err:
+        title[0] += "bg-red-100"
+        title[1] = "Title cannot be empty"
+
+    if desc_err:
+        desc[0] += "bg-red-100 h-[17rem]"
+        desc[1] = "Description cannot be empty"
+    else:
+        desc[0] += "h-[17rem]"
+
+    return title[0], desc[0], title[1], desc[1]
+
+
+def add_dashboard(name: str, desc: str) -> None:
+    test_user = login_user("dashboards-page-test-user")
+    added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
+    test_user.dashboards.append(added_dashboard)
+    test_user.save()

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -5,8 +5,6 @@ Callbacks to toggle add dashboard modal
 and submitting a new dashboard.
 """
 
-from copy import deepcopy
-
 from dash import Input, Output, State, callback, ctx
 
 from dashboard.models.user import add_dashboard
@@ -112,9 +110,9 @@ def display_error(title_err: bool, desc_err: bool) -> tuple[str, str, str, str]:
         tuple[str, str, str , str]: title, desc, title placeholder,
                                     desc placeholder
     """
-    title_css = deepcopy(input_css)
+    title_css = input_css
     title_placeholder = ""
-    desc_css = f"{deepcopy(input_css)} h-[17rem] "
+    desc_css = f"{input_css} h-[17rem] "
     desc_placeholder = ""
 
     if title_err:

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -15,14 +15,16 @@ input_css = "p-3 rounded-md shadow-inner bg-background "
 @callback(
     Output({"type": "modal-dialog", "id": "add-dashboard-dialog"}, "open", allow_duplicate=True),
     Input("create-dashboard-btn", "n_clicks"),
+    Input("create-dashboard-btn-carousel", "n_clicks"),
     Input("cancel-btn", "n_clicks"),
     prevent_initial_call=True,
 )
-def toggle_create_dashboard(create_btn: int, cancel_btn: int) -> bool:
+def toggle_create_dashboard(create_btn: int, create_btn_2: int, cancel_btn: int) -> bool:
     """Toggles the create dashboard modal.
 
     Args:
-        create_btn (int): create dashboard button clicks
+        create_btn (int): create dashboard button main
+        create_btn_2 (int): create dashboard button carousel
         cancel_btn (int): cancel button clicks
 
     Returns:
@@ -57,19 +59,19 @@ def add_dashboard_db(n_clicks: int, title: str, desc: str) -> tuple[bool, bool, 
     # Dash callback gives warnings if you pass bools to value but works
     empty_title = False
     empty_desc = False
-    valid = False
+    open = True
 
-    if title is None:
+    if title is None or not title:
         empty_title = True
 
-    if desc is None:
+    if desc is None or not desc:
         empty_desc = True
 
     if desc and title:
-        valid = True
+        open = False
         add_dashboard(title, desc)
 
-    return not valid, empty_title, empty_desc
+    return open, empty_title, empty_desc
 
 
 @callback(

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -5,6 +5,8 @@ Callbacks to toggle add dashboard modal
 and submitting a new dashboard.
 """
 
+from copy import deepcopy
+
 from dash import Input, Output, State, callback, ctx
 
 from dashboard.models.user import add_dashboard
@@ -16,10 +18,9 @@ input_css = "p-3 rounded-md shadow-inner bg-background "
     Output({"type": "modal-dialog", "id": "add-dashboard-dialog"}, "open", allow_duplicate=True),
     Input("create-dashboard-btn", "n_clicks"),
     Input("create-dashboard-btn-carousel", "n_clicks"),
-    Input("cancel-btn", "n_clicks"),
     prevent_initial_call=True,
 )
-def toggle_create_dashboard(create_btn: int, create_btn_2: int, cancel_btn: int) -> bool:
+def toggle_create_dashboard(create_btn: int, create_btn_2: int) -> bool:
     """Toggles the create dashboard modal.
 
     Args:
@@ -30,9 +31,26 @@ def toggle_create_dashboard(create_btn: int, create_btn_2: int, cancel_btn: int)
     Returns:
         bool: value to toggle modal
     """
-    if "cancel-btn" == ctx.triggered_id:
-        return False
     return True
+
+
+@callback(
+    Output({"type": "modal-dialog", "id": "add-dashboard-dialog"}, "open", allow_duplicate=True),
+    Input("cancel-btn", "n_clicks"),
+    prevent_initial_call=True,
+)
+def cancel_modal(cancel_click: int) -> bool:
+    """Close modal on cancel button.
+
+    Args:
+        cancel_click (int): Cancel button click
+
+    Returns:
+        bool: True if cancel is pressed else False
+    """
+    # Linter thinks this is Any type. Declared as bool.
+    should_close: bool = ctx.triggered_id != "cancel-btn"
+    return should_close
 
 
 @callback(
@@ -94,17 +112,17 @@ def display_error(title_err: bool, desc_err: bool) -> tuple[str, str, str, str]:
         tuple[str, str, str , str]: title, desc, title placeholder,
                                     desc placeholder
     """
-    title = [input_css, ""]
-    desc = [input_css, ""]
+    title_css = deepcopy(input_css)
+    title_placeholder = ""
+    desc_css = f"{deepcopy(input_css)} h-[17rem] "
+    desc_placeholder = ""
 
     if title_err:
-        title[0] += "bg-red-100"
-        title[1] = "Title cannot be empty"
+        title_css += "bg-red-100"
+        title_placeholder = "Title cannot be empty"
 
     if desc_err:
-        desc[0] += "bg-red-100 h-[17rem]"
-        desc[1] = "Description cannot be empty"
-    else:
-        desc[0] += "h-[17rem]"
+        desc_css += "bg-red-100"
+        desc_placeholder = "Description cannot be empty"
 
-    return title[0], desc[0], title[1], desc[1]
+    return title_css, desc_css, title_placeholder, desc_placeholder

--- a/src/dashboard/pages/index/controller.py
+++ b/src/dashboard/pages/index/controller.py
@@ -1,13 +1,13 @@
 """Index controller module.
 
-This module is intented to contain callbacks used in the index page. As
-of now it is just a stub.
+Callbacks to the index page.
+Callbacks to toggle add dashboard modal
+and submitting a new dashboard.
 """
-from datetime import datetime
 
 from dash import Input, Output, State, callback, ctx
 
-from dashboard.models.user import Dashboard, login_user
+from dashboard.models.user import add_dashboard
 
 input_css = "p-3 rounded-md shadow-inner bg-background "
 
@@ -108,16 +108,3 @@ def display_error(title_err: bool, desc_err: bool) -> tuple[str, str, str, str]:
         desc[0] += "h-[17rem]"
 
     return title[0], desc[0], title[1], desc[1]
-
-
-def add_dashboard(name: str, desc: str) -> None:
-    """Adds dashboard to mongoDB.
-
-    Args:
-        name (str): Dashboard name
-        desc (str): Dashboard description
-    """
-    test_user = login_user("dashboards-page-test-user")
-    added_dashboard = Dashboard(name=name, description=desc, created=datetime.now())
-    test_user.dashboards.append(added_dashboard)
-    test_user.save()

--- a/src/dashboard/pages/index/index.py
+++ b/src/dashboard/pages/index/index.py
@@ -2,10 +2,14 @@
 from typing import Optional
 
 import dash
-from dash import dcc, html
 from flask_login import current_user
 
-from dashboard.components import icon, login_required
+from dash import Input, Output, callback, dcc, html
+from dash_daq import BooleanSwitch
+
+from dashboard.components import icon, modal, login_required
+from dashboard.components.add_dashboard_modal import add_dashboard_modal
+import dashboard.pages.index.controller  # noqa: F401
 
 dash.register_page(__name__, path="/", name="Home", order=0, nav_item=True, icon_name="home")
 
@@ -26,8 +30,10 @@ def carousel_layout(container_title: str, id_: Optional[str] = None) -> html.Div
     Returns:
         html.Div: Div element with a carousel layout
     """
+    id = ""
     if container_title == LATEST_CONTAINER:
         empty_dashboard_text = "Create dashboard"
+        id = "create-dashboard-btn"
     else:
         empty_dashboard_text = "Add dashboard from link"
 
@@ -45,6 +51,7 @@ def carousel_layout(container_title: str, id_: Optional[str] = None) -> html.Div
                 ),
                 children=[
                     html.Div(
+                        id=id,
                         className="bg-white/70 h-full w-full flex items-center justify-center",
                         children=[icon("add_circle", fill=1, className="text-4xl text-black/75")],
                     ),
@@ -82,6 +89,9 @@ def layout() -> html.Div:
     return html.Div(
         className="flex flex-col bg-background p-10 pb-0",
         children=[
+            html.Div(id="db-add", className="hidden"),
+            BooleanSwitch(id="title", className="hidden", on=False),
+            BooleanSwitch(id="desc", className="hidden", on=False),
             html.Div(
                 className="block w-full text-3xl",
                 children=[
@@ -93,7 +103,7 @@ def layout() -> html.Div:
             html.Div(
                 className="flex justify-center w-full",
                 children=[
-                    dcc.Link(
+                    html.Button(
                         className=(
                             "bg-white w-[40rem] h-[25rem] duration-150 "
                             "[&>p]:text-2xl shadow-sm "
@@ -102,8 +112,8 @@ def layout() -> html.Div:
                             "hover:text-black hover:rounded-[20px]"
                         ),
                         children=[icon("add_circle", fill=1), html.P("Create dashboard")],
-                        id="create-dashboard",
-                        href="/create-graph",
+                        id="create-dashboard-btn",
+                        n_clicks=0,
                     )
                 ],
             ),
@@ -113,6 +123,11 @@ def layout() -> html.Div:
                     carousel_layout("Latest opened dashboards", id_="latest-opened-dashboards"),
                     carousel_layout("Shared dashboards", id_="shared-dashboards"),
                 ],
+            ),
+            modal.modal_container(
+                children=[
+                    modal.modal_dialog(id="add-dashboard-dialog", children=[add_dashboard_modal()])
+                ]
             ),
         ],
     )

--- a/src/dashboard/pages/index/index.py
+++ b/src/dashboard/pages/index/index.py
@@ -33,7 +33,7 @@ def carousel_layout(container_title: str, id_: Optional[str] = None) -> html.Div
     id = ""
     if container_title == LATEST_CONTAINER:
         empty_dashboard_text = "Create dashboard"
-        id = "create-dashboard-btn"
+        id = "create-dashboard-btn-carousel"
     else:
         empty_dashboard_text = "Add dashboard from link"
 

--- a/src/dashboard/pages/index/index.py
+++ b/src/dashboard/pages/index/index.py
@@ -124,10 +124,6 @@ def layout() -> html.Div:
                     carousel_layout("Shared dashboards", id_="shared-dashboards"),
                 ],
             ),
-            modal.modal_container(
-                children=[
-                    modal.modal_dialog(id="add-dashboard-dialog", children=[add_dashboard_modal()])
-                ]
-            ),
+            add_dashboard_modal(),
         ],
     )

--- a/src/dashboard/pages/index/index.py
+++ b/src/dashboard/pages/index/index.py
@@ -2,12 +2,11 @@
 from typing import Optional
 
 import dash
+from dash import html
+from dash_daq import BooleanSwitch
 from flask_login import current_user
 
-from dash import Input, Output, callback, dcc, html
-from dash_daq import BooleanSwitch
-
-from dashboard.components import icon, modal, login_required
+from dashboard.components import icon, login_required
 from dashboard.components.add_dashboard_modal import add_dashboard_modal
 import dashboard.pages.index.controller  # noqa: F401
 

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -13,6 +13,7 @@ from dashboard.pages.index import controller
 from .settings import DriverType
 
 CREATE_DASHBOARD_BUTTON_ID = "create-dashboard-btn"
+DASHBOARD_MODAL_ID = "modal-container"
 LATEST_OPENED_DASHBOARDS_ID = "latest-opened-dashboards"
 SHARED_DASHBOARDS_ID = "shared-dashboards"
 USERNAME = "home-page-user"
@@ -61,8 +62,6 @@ def example_user():
 class TestHomePage:
     """A class to group functions to test home page."""
 
-    pytest.mark.usefixtures("start_server")
-
     @pytest.mark.usefixtures("start_server", "login_session")
     def test_create_dashboard_button(self, browser_driver: DriverType) -> None:
         """Test the create dashboard button.
@@ -76,20 +75,15 @@ class TestHomePage:
             browser_driver, CREATE_DASHBOARD_BUTTON_ID
         )
         create_dashboard.click()
+        dashboard_modal: WebElement = helper.get_element_by_id(browser_driver, DASHBOARD_MODAL_ID)
+        assert "hidden" not in dashboard_modal.get_attribute("class")
 
-    @pytest.mark.usefixtures("start_server")
-    def test_create_dashboard(self, browser_driver: DriverType) -> None:
+    def test_create_dashboard(self) -> None:
         """Tries to create dashboards using callback.
 
         Args:
             browser_driver (DriverType): webdriver used for selenium
         """
-        browser_driver.get(settings.HOME_PAGE_URL)
-
-        create_dashboard: WebElement = helper.get_element_by_id(
-            browser_driver, CREATE_DASHBOARD_BUTTON_ID
-        )
-        create_dashboard.click()
         empty_title_output = controller.add_dashboard_db(0, "", "Text")
         valid_dashboard_output = controller.add_dashboard_db(0, "Title", "Text")
         empty_desc_output = controller.add_dashboard_db(0, "Title", "")

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,10 +1,13 @@
 """Test home page."""
 
+import mongoengine
+import mongomock
 import pytest
 from selenium.webdriver.remote.webelement import WebElement
 from tests import helper_test_functions as helper
 from tests import settings
 
+from dashboard.models import user
 from dashboard.pages.index import controller
 
 from .settings import DriverType
@@ -33,9 +36,32 @@ def login_session(browser_driver: DriverType) -> None:
     helper.try_login(browser_driver, USERNAME, PASSWORD)
 
 
+@pytest.fixture(autouse=True)
+def connection():
+    """Connect mongoengine to mongomock and return client."""
+    conn = mongoengine.connect(
+        db="dashboard",
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+        uuidRepresentation="standard",
+    )
+
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def example_user():
+    """Example user."""
+    username = "dashboards-page-test-user"
+    usr = user.login_user(username)
+    return usr
+
+
 @pytest.mark.test_home_page
 class TestHomePage:
-    """A class to group functions to test the dashboard capabilities."""
+    """A class to group functions to test home page."""
+
+    pytest.mark.usefixtures("start_server")
 
     @pytest.mark.usefixtures("start_server", "login_session")
     def test_create_dashboard_button(self, browser_driver: DriverType) -> None:

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -5,9 +5,11 @@ from selenium.webdriver.remote.webelement import WebElement
 from tests import helper_test_functions as helper
 from tests import settings
 
+from dashboard.pages.index import controller
+
 from .settings import DriverType
 
-CREATE_DASHBOARD_BUTTON_ID = "create-dashboard"
+CREATE_DASHBOARD_BUTTON_ID = "create-dashboard-btn"
 LATEST_OPENED_DASHBOARDS_ID = "latest-opened-dashboards"
 SHARED_DASHBOARDS_ID = "shared-dashboards"
 USERNAME = "home-page-user"
@@ -18,6 +20,10 @@ PASSWORD = "password"
 TODO
 Add tests for modals when modal component is finished
 """
+EMPTY_TITLE_OUTPUT = (True, True, False)
+EMPTY_DESC_OUTPUT = (True, False, True)
+EMPTY_TITLE_DESC_OUTPUT = (True, True, True)
+VALID_OUTPUT = (False, False, False)
 
 
 @pytest.fixture(scope="class")
@@ -33,15 +39,39 @@ class TestHomePage:
 
     @pytest.mark.usefixtures("start_server", "login_session")
     def test_create_dashboard_button(self, browser_driver: DriverType) -> None:
-        """Check that the create dashboard button exists.
+        """Test the create dashboard button.
 
         Args:
             browser_driver (DriverType): webdriver used for selenium
         """
-        browser_driver.get(settings.URL)
+        browser_driver.get(settings.HOME_PAGE_URL)
 
-        element: WebElement = helper.get_element_by_id(browser_driver, CREATE_DASHBOARD_BUTTON_ID)
-        assert element
+        create_dashboard: WebElement = helper.get_element_by_id(
+            browser_driver, CREATE_DASHBOARD_BUTTON_ID
+        )
+        create_dashboard.click()
+
+    @pytest.mark.usefixtures("start_server")
+    def test_create_dashboard(self, browser_driver: DriverType) -> None:
+        """Tries to create dashboards using callback.
+
+        Args:
+            browser_driver (DriverType): webdriver used for selenium
+        """
+        browser_driver.get(settings.HOME_PAGE_URL)
+
+        create_dashboard: WebElement = helper.get_element_by_id(
+            browser_driver, CREATE_DASHBOARD_BUTTON_ID
+        )
+        create_dashboard.click()
+        empty_title_output = controller.add_dashboard_db(0, "", "Text")
+        valid_dashboard_output = controller.add_dashboard_db(0, "Title", "Text")
+        empty_desc_output = controller.add_dashboard_db(0, "Title", "")
+        empty_title_desc_ouput = controller.add_dashboard_db(0, "", "")
+        assert empty_title_output == EMPTY_TITLE_OUTPUT
+        assert valid_dashboard_output == VALID_OUTPUT
+        assert empty_desc_output == EMPTY_DESC_OUTPUT
+        assert empty_title_desc_ouput == EMPTY_TITLE_DESC_OUTPUT
 
     @pytest.mark.usefixtures("start_server", "login_session")
     def test_carousel(self, browser_driver: DriverType) -> None:
@@ -50,6 +80,6 @@ class TestHomePage:
         Args:
             browser_driver (DriverType): webdriver used for selenium
         """
-        browser_driver.get(settings.URL)
+        browser_driver.get(settings.HOME_PAGE_URL)
         helper.get_element_by_id(browser_driver, LATEST_OPENED_DASHBOARDS_ID)
         helper.get_element_by_id(browser_driver, SHARED_DASHBOARDS_ID)

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,5 +1,8 @@
 """Test home page."""
 
+from flask import Flask
+from flask.ctx import RequestContext
+from flask_login import LoginManager
 import mongoengine
 import mongomock
 import pytest
@@ -8,6 +11,7 @@ from tests import helper_test_functions as helper
 from tests import settings
 
 from dashboard.models import user
+from dashboard.models.user import User, login_user
 from dashboard.pages.index import controller
 
 from .settings import DriverType
@@ -50,12 +54,41 @@ def connection():
     return conn
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def example_user():
     """Example user."""
     username = "dashboards-page-test-user"
     usr = user.login_user(username)
     return usr
+
+
+@pytest.fixture
+def app() -> Flask:
+    """Return a Flask app."""
+    app = Flask(__name__)
+    app.secret_key = "test-key123"
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id: str) -> User:
+        """Load a user by id.
+
+        Required by flask-login. For more information, see
+        https://flask-login.readthedocs.io/en/latest/#your-user-class
+        """
+        user: User = User.objects(id=user_id).get()
+
+        return user
+
+    return app
+
+
+@pytest.fixture
+def ctx(app: Flask) -> RequestContext:
+    """Yield a flask request context."""
+    with app.test_request_context() as ctx:
+        yield ctx
 
 
 @pytest.mark.test_home_page
@@ -78,12 +111,16 @@ class TestHomePage:
         dashboard_modal: WebElement = helper.get_element_by_id(browser_driver, DASHBOARD_MODAL_ID)
         assert "hidden" not in dashboard_modal.get_attribute("class")
 
-    def test_create_dashboard(self) -> None:
+    @pytest.mark.usefixtures("start_server", "login_session")
+    def test_create_dashboard(self, ctx: RequestContext, example_user: User) -> None:
         """Tries to create dashboards using callback.
 
         Args:
             browser_driver (DriverType): webdriver used for selenium
+            ctx (RequestContext): flask context
+            example_user (User): User model to login
         """
+        login_user(example_user.username)
         empty_title_output = controller.add_dashboard_db(0, "", "Text")
         valid_dashboard_output = controller.add_dashboard_db(0, "Title", "Text")
         empty_desc_output = controller.add_dashboard_db(0, "Title", "")


### PR DESCRIPTION
**Changes:**
Modal for adding dashboards are now available. It is a component that can be reused on other pages.
I have added integrated this modal into the home page.
Users can now type in a title and description for their dashboard and add it to the database.

**I have:**
<!-- fill in with [x] -->
- [x] Set target branch to the correct branch, usually `dev`.
- [x] Rebased source branch from the target branch.
- [x] Ensured code is formatted and linted.
- [x] Cleaned up git history.
- [x] Ensured commit messages describe *what* was changed and *why*.
- [x] Ran tests locally after rebasing and checked output.
